### PR TITLE
Use environment variables for Supabase credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Leavn App
+
+## Setup
+
+1. Inside the project directory (`horizons-export-*`), copy `.env.example` to `.env` and provide your Supabase credentials.
+2. Install dependencies with `npm install`.
+3. Run the dev server using `npm run dev`.
+
+The `populate_supabase.mjs` script uses the same environment variables. Run it with:
+
+```bash
+node populate_supabase.mjs
+```
+
+Ensure `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` are set in your environment before running the script.

--- a/horizons-export-c9182d65-e7fd-47fe-9d3c-97d386287da1/.env.example
+++ b/horizons-export-c9182d65-e7fd-47fe-9d3c-97d386287da1/.env.example
@@ -1,0 +1,3 @@
+# Rename this file to .env and provide your Supabase credentials
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=

--- a/horizons-export-c9182d65-e7fd-47fe-9d3c-97d386287da1/populate_supabase.mjs
+++ b/horizons-export-c9182d65-e7fd-47fe-9d3c-97d386287da1/populate_supabase.mjs
@@ -7,8 +7,8 @@ import { createClient } from '@supabase/supabase-js';
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = path.dirname(__filename);
 
-    const supabaseUrl = 'https://gegergaanossklhfcowe.supabase.co';
-    const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdlZ2VyZ2Fhbm9zc2tsaGZjb3dlIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc3MDIwNTksImV4cCI6MjA2MzI3ODA1OX0.irpWBnKuPHExDOLFia-skPBPjgTlQhOaPLT5Ehiosk0';
+    const supabaseUrl = process.env.VITE_SUPABASE_URL;
+    const supabaseAnonKey = process.env.VITE_SUPABASE_ANON_KEY;
 
     const supabase = createClient(supabaseUrl, supabaseAnonKey);
 

--- a/horizons-export-c9182d65-e7fd-47fe-9d3c-97d386287da1/src/lib/supabaseClient.js
+++ b/horizons-export-c9182d65-e7fd-47fe-9d3c-97d386287da1/src/lib/supabaseClient.js
@@ -1,7 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 
-    const supabaseUrl = 'https://gegergaanossklhfcowe.supabase.co';
-    const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdlZ2VyZ2Fhbm9zc2tsaGZjb3dlIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc3MDIwNTksImV4cCI6MjA2MzI3ODA1OX0.irpWBnKuPHExDOLFia-skPBPjgTlQhOaPLT5Ehiosk0';
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
     
     export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
       auth: {


### PR DESCRIPTION
## Summary
- document environment setup
- add `.env.example`
- load Supabase credentials from `import.meta.env`
- update population script to read from `process.env`

## Testing
- `npm run build` *(fails: vite not found)*